### PR TITLE
fix Signature.prototype.hasDefinedHashtype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ bch-lib.min.js
 bch-lib.js.sig
 bch-lib.min.js.sig
 tests.js
+
+package-lock.json

--- a/lib/crypto/signature.js
+++ b/lib/crypto/signature.js
@@ -293,7 +293,7 @@ Signature.prototype.hasDefinedHashtype = function() {
   }
   // accept with or without Signature.SIGHASH_ANYONECANPAY by ignoring the bit
   var temp = this.nhashtype & ~Signature.SIGHASH_ANYONECANPAY;
-  if (temp < Signature.SIGHASH_ALL || temp > Signature.SIGHASH_SINGLE) {
+  if (temp < (Signature.SIGHASH_ALL|Signature.SIGHASH_FORKID) || temp > (Signature.SIGHASH_SINGLE|Signature.SIGHASH_FORKID)) {
     return false;
   }
   return true;

--- a/lib/crypto/signature.js
+++ b/lib/crypto/signature.js
@@ -293,7 +293,11 @@ Signature.prototype.hasDefinedHashtype = function() {
   }
   // accept with or without Signature.SIGHASH_ANYONECANPAY by ignoring the bit
   var temp = this.nhashtype & ~Signature.SIGHASH_ANYONECANPAY;
-  if (temp < (Signature.SIGHASH_ALL|Signature.SIGHASH_FORKID) || temp > (Signature.SIGHASH_SINGLE|Signature.SIGHASH_FORKID)) {
+
+  // accept with or without Signature.SIGHASH_FORKID by ignoring it too
+  temp = temp & ~Signature.SIGHASH_FORKID;
+
+  if (temp < Signature.SIGHASH_ALL || temp > Signature.SIGHASH_SINGLE) {
     return false;
   }
   return true;

--- a/lib/transaction/transaction.js
+++ b/lib/transaction/transaction.js
@@ -1051,6 +1051,8 @@ Transaction.prototype.removeInput = function(txId, outputIndex) {
 Transaction.prototype.sign = function(privateKey, sigtype) {
   $.checkState(this.hasAllUtxoInfo());
   var self = this;
+  sigtype = sigtype || Signature.SIGHASH_ALL;
+
   if (_.isArray(privateKey)) {
     _.each(privateKey, function(privateKey) {
       self.sign(privateKey, sigtype);
@@ -1065,8 +1067,6 @@ Transaction.prototype.sign = function(privateKey, sigtype) {
 
 Transaction.prototype.getSignatures = function(privKey, sigtype) {
   privKey = new PrivateKey(privKey);
-  // By default, signs using ALL|FORKID
-  sigtype = sigtype || (Signature.SIGHASH_ALL |  Signature.SIGHASH_FORKID);
   var transaction = this;
   var results = [];
   var hashData = Hash.sha256ripemd160(privKey.publicKey.toBuffer());


### PR DESCRIPTION
While investigating issues with bch-channel tests, ran into this. Seems wrong. Let's discuss.